### PR TITLE
Update `Statistex.variance` to use Welford's online algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ elixir_build_*
 doc
 docs
 /test/tmp
+.DS_Store
 
 # Don't feel like tracking that gives me what I want any more :)
 .tool-versions

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ iex> Statistex.statistics(samples)
   standard_deviation: 10.47189577445799,
   standard_deviation_ratio: 1.46316833512058,
   total: 71.57,
+  m2: 986.9454099999999,
   variance: 109.6606011111111
 }
 # or just calculate the value you need
@@ -127,3 +128,7 @@ A couple of (hopefully) helpful points:
 * `mix test` to run tests
 * `mix dialyzer` to run dialyzer for type checking, might take a while on the first invocation (try building plts first with `mix dialyzer --plt`)
 * `mix credo` to find code style problems
+* To generate code coverage information:
+    * `mix test --cover --export-coverage default`
+    * `mix test.coverage`
+    * Open HTML files in the `cover/` directory


### PR DESCRIPTION
Earlier today I opened bencheeorg/benchee#472, and I started thinking about how Statistex could be used to accomplish this. Statistex already supports calculating several statistics while ignoring the list of samples, if the prerequisite parts are available to the caller (e.g. `average` can be called with `:total` and `:sample_size`)

One statistic that didn't support this today was `variance` (and by extension `standard_deviation`), since both require the entire list of samples to operate. Algorithms to calculate variance "on-line" exist, such as [Welford's Online Algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm), but they depend on a different statistic, `m2`. This statistic is "the running sum of squared differences from the current mean", and really only has a meaning in the context of computing variance.

In this PR, I've:
- added this `m2` statistic
- updated the `variance` statistic to use `m2` when calculating `variance` instead of `average`
- I also exposed this `m2` statistic on the top level `Statistex` struct, even if it's not a particularly useful statistic on its own.
    - (I figured the ability for users to incrementally update statistics like `variance` and `standard_deviation` was in keeping with Statistex's philosophy of avoiding recomputation.)

This PR also updates some typespecs to better capture the `:ignored` behavior for statistics that support it, and tweaks the last few digits of floating point results from the `variance` and `standard_deviation` statistic. I'm not a statistics expert, but I believe that my floating point tweaks represent a shift towards _more accuracy_, not less, given the notes about loss of precision on the above linked Wikipedia page:

> [The Welford's online] algorithm is much less prone to loss of precision due to [catastrophic cancellation](https://en.wikipedia.org/wiki/Catastrophic_cancellation), but might not be as efficient because of the division operation inside the loop.

I didn't open an issue before I opened this PR, so I know these changes might not be desired - if so, please let me know! I'd love to discuss better ways to handle what I described in bencheeorg/benchee#472 if this isn't the best approach.